### PR TITLE
Add support for expiration bundle.  Allow user to set default databas…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ var log = new LoggerConfiguration()
     .CreateLogger();
 ```
 
-You'll need to create a database on the server for logs, and specify this as your default database in the connection string or `DocumentStore.DefaultDatabase`.
+You'll need to create a database on the server for logs, and specify this as your default database in the connection string or `DocumentStore.DefaultDatabase`.  In the alternative, you can pass a default database when configuring the RavenDB sink.
+
+## Support for Automatic Log Record Expiration
+If you install the RavenDB expiration bundle on the database where log records are stored, you can configure the
+sink to automatically delete log records by passing errorExpirationTimeSpan (for fatal and error messages) and
+expirationTimeSpan (for all other messages). If you pass one, you should pass both. TimeSpan.Zero indicates that
+messages of the appropriate type will never be deleted by the expiration bundle.
+
 
 [(More information.)](http://nblumhardt.com/2013/06/serilog-and-ravendb/)

--- a/src/Serilog.Sinks.RavenDB/LoggerConfigurationRavenDBExtensions.cs
+++ b/src/Serilog.Sinks.RavenDB/LoggerConfigurationRavenDBExtensions.cs
@@ -34,6 +34,9 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="defaultDatabase">Optional default database</param>
+        /// <param name="expirationTimeSpan">Optional time before a logged message will be expired assuming the expiration bundle is installed. Zero (00:00:00) means no expiration. If this is not provided but errorExpirationTimeSpan is, errorExpirationTimeSpan will be used for non-errors too.</param>
+        /// <param name="errorExpirationTimeSpan">Optional time before a logged error message will be expired assuming the expiration bundle is installed.  Zero (00:00:00) means no expiration. If this is not provided but expirationTimeSpan is, expirationTimeSpan will be used for errors too.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration RavenDB(
@@ -42,14 +45,17 @@ namespace Serilog
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = RavenDBSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            string defaultDatabase = null,
+            TimeSpan? expirationTimeSpan = null,
+            TimeSpan? errorExpirationTimeSpan = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (documentStore == null) throw new ArgumentNullException("documentStore");
 
             var defaultedPeriod = period ?? RavenDBSink.DefaultPeriod;
             return loggerConfiguration.Sink(
-                new RavenDBSink(documentStore, batchPostingLimit, defaultedPeriod, formatProvider),
+                new RavenDBSink(documentStore, batchPostingLimit, defaultedPeriod, formatProvider, defaultDatabase, expirationTimeSpan, errorExpirationTimeSpan),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.RavenDB/LoggerConfigurationRavenDBExtensions.cs
+++ b/src/Serilog.Sinks.RavenDB/LoggerConfigurationRavenDBExtensions.cs
@@ -35,8 +35,8 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="defaultDatabase">Optional default database</param>
-        /// <param name="expirationTimeSpan">Optional time before a logged message will be expired assuming the expiration bundle is installed. Zero (00:00:00) means no expiration. If this is not provided but errorExpirationTimeSpan is, errorExpirationTimeSpan will be used for non-errors too.</param>
-        /// <param name="errorExpirationTimeSpan">Optional time before a logged error message will be expired assuming the expiration bundle is installed.  Zero (00:00:00) means no expiration. If this is not provided but expirationTimeSpan is, expirationTimeSpan will be used for errors too.</param>
+        /// <param name="expiration">Optional time before a logged message will be expired assuming the expiration bundle is installed. <see cref="System.Threading.Timeout.InfiniteTimeSpan">Timeout.InfiniteTimeSpan</see> (-00:00:00.0010000) means no expiration. If this is not provided but errorExpiration is, errorExpiration will be used for non-errors too.</param>
+        /// <param name="errorExpiration">Optional time before a logged error message will be expired assuming the expiration bundle is installed.  <see cref="System.Threading.Timeout.InfiniteTimeSpan">Timeout.InfiniteTimeSpan</see> (-00:00:00.0010000) means no expiration. If this is not provided but expiration is, expiration will be used for errors too.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration RavenDB(
@@ -47,15 +47,15 @@ namespace Serilog
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             string defaultDatabase = null,
-            TimeSpan? expirationTimeSpan = null,
-            TimeSpan? errorExpirationTimeSpan = null)
+            TimeSpan? expiration = null,
+            TimeSpan? errorExpiration = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (documentStore == null) throw new ArgumentNullException("documentStore");
 
             var defaultedPeriod = period ?? RavenDBSink.DefaultPeriod;
             return loggerConfiguration.Sink(
-                new RavenDBSink(documentStore, batchPostingLimit, defaultedPeriod, formatProvider, defaultDatabase, expirationTimeSpan, errorExpirationTimeSpan),
+                new RavenDBSink(documentStore, batchPostingLimit, defaultedPeriod, formatProvider, defaultDatabase, expiration, errorExpiration),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.RavenDB/Serilog.Sinks.RavenDB.csproj
+++ b/src/Serilog.Sinks.RavenDB/Serilog.Sinks.RavenDB.csproj
@@ -46,21 +46,21 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Raven.Abstractions, Version=2.5.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\RavenDB.Client.2.5.2750\lib\net45\Raven.Abstractions.dll</HintPath>
+    <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Raven.Client.Lightweight, Version=2.5.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\RavenDB.Client.2.5.2750\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+    <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/Serilog.Sinks.RavenDB/packages.config
+++ b/src/Serilog.Sinks.RavenDB/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RavenDB.Client" version="2.5.2750" targetFramework="net45" />
-  <package id="Serilog" version="1.4.204" targetFramework="net45" />
+  <package id="RavenDB.Client" version="3.0.30000" targetFramework="net45" />
+  <package id="Serilog" version="1.5.14" targetFramework="net45" />
 </packages>

--- a/test/Serilog.Sinks.RavenDB.Tests/Serilog.Sinks.RavenDB.Tests.csproj
+++ b/test/Serilog.Sinks.RavenDB.Tests/Serilog.Sinks.RavenDB.Tests.csproj
@@ -51,8 +51,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -101,9 +102,6 @@
     </None>
     <None Include="app.config" />
     <None Include="packages.config" />
-    <None Include="Raven.Studio.Html5.zip">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/test/Serilog.Sinks.RavenDB.Tests/Serilog.Sinks.RavenDB.Tests.csproj
+++ b/test/Serilog.Sinks.RavenDB.Tests/Serilog.Sinks.RavenDB.Tests.csproj
@@ -54,9 +54,9 @@
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\..\packages\RavenDB.Database.3.0.30000\lib\net45\Raven.Abstractions.dll</HintPath>

--- a/test/Serilog.Sinks.RavenDB.Tests/Serilog.Sinks.RavenDB.Tests.csproj
+++ b/test/Serilog.Sinks.RavenDB.Tests/Serilog.Sinks.RavenDB.Tests.csproj
@@ -58,29 +58,25 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Raven.Abstractions, Version=2.5.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\RavenDB.Client.2.5.2750\lib\net45\Raven.Abstractions.dll</HintPath>
+    <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RavenDB.Database.3.0.30000\lib\net45\Raven.Abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Raven.Client.Embedded, Version=2.5.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\RavenDB.Embedded.2.5.2750\lib\net45\Raven.Client.Embedded.dll</HintPath>
+    <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Raven.Client.Lightweight, Version=2.5.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\RavenDB.Client.2.5.2750\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+    <Reference Include="Raven.Database, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RavenDB.Database.3.0.30000\lib\net45\Raven.Database.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Raven.Database, Version=2.5.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\RavenDB.Database.2.5.2750\lib\net45\Raven.Database.dll</HintPath>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -105,6 +101,9 @@
     </None>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <None Include="Raven.Studio.Html5.zip">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/test/Serilog.Sinks.RavenDB.Tests/app.config
+++ b/test/Serilog.Sinks.RavenDB.Tests/app.config
@@ -20,7 +20,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/Serilog.Sinks.RavenDB.Tests/app.config
+++ b/test/Serilog.Sinks.RavenDB.Tests/app.config
@@ -18,6 +18,10 @@
         <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/Serilog.Sinks.RavenDB.Tests/packages.config
+++ b/test/Serilog.Sinks.RavenDB.Tests/packages.config
@@ -6,10 +6,10 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
-  <package id="RavenDB.Client" version="2.5.2750" targetFramework="net45" />
-  <package id="RavenDB.Database" version="2.5.2750" targetFramework="net45" />
-  <package id="RavenDB.Embedded" version="2.5.2750" targetFramework="net45" />
-  <package id="Serilog" version="1.4.204" targetFramework="net45" />
+  <package id="RavenDB.Client" version="3.0.30000" targetFramework="net45" />
+  <package id="RavenDB.Database" version="3.0.30000" targetFramework="net45" />
+  <package id="RavenDB.Embedded" version="3.0.30000" targetFramework="net45" />
+  <package id="Serilog" version="1.5.14" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.3" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/test/Serilog.Sinks.RavenDB.Tests/packages.config
+++ b/test/Serilog.Sinks.RavenDB.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Data.OData" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="RavenDB.Client" version="3.0.30000" targetFramework="net45" />
   <package id="RavenDB.Database" version="3.0.30000" targetFramework="net45" />

--- a/test/Serilog.Sinks.RavenDB.Tests/packages.config
+++ b/test/Serilog.Sinks.RavenDB.Tests/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
-  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="RavenDB.Client" version="3.0.30000" targetFramework="net45" />
   <package id="RavenDB.Database" version="3.0.30000" targetFramework="net45" />
   <package id="RavenDB.Embedded" version="3.0.30000" targetFramework="net45" />


### PR DESCRIPTION
…e when configuring seilog to allow for case where using embedded wihtout a default databse at the connection level.

Because this is currently referencing the 2.5 version of the RavenDB client, I had to use a non-async method to get metadata. If we upgrade to 3.0, there is an async version of that method. If you would like me to upgrade the library as part of this pull request, please let me know.

Note that I allow for the default database to be set to allow my use of the lib in an application that uses an embedded database. My connection needs to point at the system database to allow the application to create a tenant database with proper settings. Therefore, I need a way to pass the tenant to the sink.
