### PR TITLE
Correct minimum version of RavenDB.Client for the sink's nuget package

### DIFF
--- a/src/Serilog.Sinks.RavenDB/Serilog.Sinks.RavenDB.nuspec
+++ b/src/Serilog.Sinks.RavenDB/Serilog.Sinks.RavenDB.nuspec
@@ -12,7 +12,7 @@
     <tags>serilog logging ravendb</tags>
     <dependencies>
       <dependency id="Serilog" version="[1.4.204,2)" />
-      <dependency id="RavenDB.Client" version="2.5.2750" />
+      <dependency id="RavenDB.Client" version="3.0.30000" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
This now requires version 3 of the RavenDB.Client to support setting metadata asynchronously.
