### PR TITLE
Add extension method & ctor to ease configuration through external config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ var log = new LoggerConfiguration()
 
 You'll need to create a database on the server for logs, and specify this as your default database in the connection string or `DocumentStore.DefaultDatabase`.  In the alternative, you can pass a default database when configuring the RavenDB sink. [More information](http://nblumhardt.com/2013/06/serilog-and-ravendb/).
 
+You can also configure the sink through your application config file using [Serilog.Settings.AppSettings](https://www.nuget.org/packages/Serilog.Settings.AppSettings)
+```csharp
+Log.Logger = new LoggerConfiguration()
+    .ReadFrom.AppSettings()
+    .CreateLogger();
+```
+```xml
+<connectionStrings>
+  <add name="Logs" connectionString="Url=http://[RAVEN_DB_SERVER]:8080/;DefaultDatabase=[OPTIONAL_DEFAULT_DATABASE]" />
+</connectionStrings>
+<appSettings>
+  <add key="serilog:minimum-level" value="Information" />
+  <add key="serilog:using:RavenDB" value="Serilog.Sinks.RavenDB" />
+  <add key="serilog:write-to:RavenDB.connectionStringName" value="Logs" />
+  <add key="serilog:write-to:RavenDB.defaultDatabase" value="[DEFAULT_DATABASE]" />
+</appSettings>
+```
+
 ### Automatic Log Record Expiration
 
 If you install the RavenDB expiration bundle on the database where log records are stored, you can configure the

--- a/src/Serilog.Sinks.RavenDB/LoggerConfigurationRavenDBExtensions.cs
+++ b/src/Serilog.Sinks.RavenDB/LoggerConfigurationRavenDBExtensions.cs
@@ -50,13 +50,55 @@ namespace Serilog
             TimeSpan? expiration = null,
             TimeSpan? errorExpiration = null)
         {
-            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
-            if (documentStore == null) throw new ArgumentNullException("documentStore");
+            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
+            if (documentStore == null) throw new ArgumentNullException(nameof(documentStore));
 
             var defaultedPeriod = period ?? RavenDBSink.DefaultPeriod;
             return loggerConfiguration.Sink(
                 new RavenDBSink(documentStore, batchPostingLimit, defaultedPeriod, formatProvider, defaultDatabase, expiration, errorExpiration),
                 restrictedToMinimumLevel);
+        }
+
+        /// <summary>
+        /// Adds a sink that writes log events as documents to a RavenDB database. Creates a document store using the specified connection string name.
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="connectionStringName">Connection string name to the RavenDB database.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="defaultDatabase">Optional default database</param>
+        /// <param name="expiration">Optional time before a logged message will be expired assuming the expiration bundle is installed. <see cref="System.Threading.Timeout.InfiniteTimeSpan">Timeout.InfiniteTimeSpan</see> (-00:00:00.0010000) means no expiration. If this is not provided but errorExpiration is, errorExpiration will be used for non-errors too.</param>
+        /// <param name="errorExpiration">Optional time before a logged error message will be expired assuming the expiration bundle is installed.  <see cref="System.Threading.Timeout.InfiniteTimeSpan">Timeout.InfiniteTimeSpan</see> (-00:00:00.0010000) means no expiration. If this is not provided but expiration is, expiration will be used for errors too.</param>
+        /// <returns>Logger configuration, allowing configuration to continue.</returns>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration RavenDB(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string connectionStringName,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            int batchPostingLimit = RavenDBSink.DefaultBatchPostingLimit,
+            TimeSpan? period = null,
+            IFormatProvider formatProvider = null,
+            string defaultDatabase = null,
+            TimeSpan? expiration = null,
+            TimeSpan? errorExpiration = null)
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
+            if (string.IsNullOrWhiteSpace(connectionStringName)) throw new ArgumentNullException(nameof(connectionStringName));
+
+            var defaultedPeriod = period ?? RavenDBSink.DefaultPeriod;
+            return
+                loggerConfiguration.Sink(
+                    new RavenDBSink(
+                        connectionStringName,
+                        batchPostingLimit,
+                        defaultedPeriod,
+                        formatProvider,
+                        defaultDatabase,
+                        expiration,
+                        errorExpiration),
+                    restrictedToMinimumLevel);
         }
     }
 }

--- a/test/Serilog.Sinks.RavenDB.Tests/DocumentStoreTestListener.cs
+++ b/test/Serilog.Sinks.RavenDB.Tests/DocumentStoreTestListener.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using Raven.Client.Listeners;
+using Raven.Json.Linq;
+using LogEvent = Serilog.Sinks.RavenDB.Data.LogEvent;
+
+namespace Serilog.Sinks.RavenDB.Tests
+{
+    public class DocumentStoreTestListener : IDocumentStoreListener
+    {
+        public Dictionary<string, LogEvent> Events { get; set; } = new Dictionary<string, LogEvent>();
+
+        public bool BeforeStore(string key, object entityInstance, RavenJObject metadata, RavenJObject original)
+        {
+            return true;
+        }
+
+        public void AfterStore(string key, object entityInstance, RavenJObject metadata)
+        {
+            Events.Add(key, (LogEvent) entityInstance);
+        }
+    }
+}

--- a/test/Serilog.Sinks.RavenDB.Tests/Serilog.Sinks.RavenDB.Tests.csproj
+++ b/test/Serilog.Sinks.RavenDB.Tests/Serilog.Sinks.RavenDB.Tests.csproj
@@ -93,6 +93,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DocumentStoreTestListener.cs" />
     <Compile Include="RavenDBSinkTests.cs" />
     <Compile Include="RavenPropertyFormatterTests.cs" />
   </ItemGroup>

--- a/test/Serilog.Sinks.RavenDB.Tests/app.config
+++ b/test/Serilog.Sinks.RavenDB.Tests/app.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <connectionStrings>
+    <add name="testConnectionRavenDb" connectionString="DataDir = ~\App_Data\Data"/>
+  </connectionStrings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>


### PR DESCRIPTION
In order to ease sink configuration through external config files, an extension method and a constructor are added with simple data types, available to fill in in the config.